### PR TITLE
Allow reading rasters from disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Flood Damage Estimator
+
+This Streamlit app estimates agricultural flood damages from cropland and flood depth rasters.
+
+## Usage
+
+1. Install requirements:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   streamlit run app.py
+   ```
+
+## Providing Raster Data
+
+You may either upload `.tif` files directly in the sidebar or provide paths to existing files on disk:
+
+- **Crop Raster Path (optional)** – Enter the path to a local cropland raster.
+- **Flood Raster Paths (optional, one per line)** – Enter one or more flood depth raster paths.
+
+If paths are supplied, the application reads the files directly with `rasterio`, bypassing Streamlit's upload size limit.


### PR DESCRIPTION
## Summary
- add sidebar inputs to specify paths to `.tif` files
- open rasters directly with rasterio when paths are provided
- document how to bypass Streamlit upload limits in `README.md`

## Testing
- `python -m py_compile app.py utils/processing.py`

------
https://chatgpt.com/codex/tasks/task_e_68893f281d008330ac91047ebf5c1234