### PR TITLE
Fix temporary file deletion timing

### DIFF
--- a/app.py
+++ b/app.py
@@ -183,7 +183,6 @@ if mode == "Direct Damages":
         if not (crop_file and (depth_files or polygon_file)):
             st.error("❌ Please upload a cropland raster and at least one flood source.")
         else:
-            cleanup_temp_files()
             cleanup_temp_dir()
             st.session_state.temp_dir = tempfile.TemporaryDirectory()
             with st.spinner("🔄 Processing flood damages..."):
@@ -247,7 +246,6 @@ elif mode == "Monte Carlo Simulation":
         if not (crop_file and (depth_files or polygon_file)):
             st.error("❌ Please upload a cropland raster and at least one flood source.")
         else:
-            cleanup_temp_files()
             cleanup_temp_dir()
             st.session_state.temp_dir = tempfile.TemporaryDirectory()
             with st.spinner("🔬 Running Monte Carlo..."):


### PR DESCRIPTION
## Summary
- avoid deleting temp files before running damage calculations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a447f3bac83308f2ec7f9307b93d2