### PR TITLE
Improve polygon workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If paths are supplied, the application reads the files directly with `rasterio`,
 
 ## Polygon Uploads
 
-In place of a flood depth raster you may also upload a polygon layer (zipped Shapefile, GeoJSON, or KML). The polygon is rasterized to the crop raster's grid and assigned a uniform depth of **0.5&nbsp;ft** (6&nbsp;inches). The resulting depth array is processed just like any other flood raster when computing damages.
+You may also provide a polygon layer (zipped Shapefile, GeoJSON, or KML) instead of a flood depth raster. Cells of the crop raster inside the polygon are assumed to receive **0.5&nbsp;ft** (6&nbsp;inches) of flooding. The original file names of uploaded rasters and polygons become the labels in the output Excel workbook.
 
 
 ## Running Tests

--- a/app.py
+++ b/app.py
@@ -131,7 +131,8 @@ if depth_files or polygon_file:
             path = tempfile.NamedTemporaryFile(delete=False, suffix=".tif").name
             with open(path, "wb") as out:
                 out.write(f.read())
-            depth_inputs.append(path)
+            label = os.path.splitext(os.path.basename(f.name))[0]
+            depth_inputs.append((label, path))
             st.session_state.temp_files.append(path)
             rp = st.number_input(
                 f"Return Period: {f.name}", min_value=1, value=100,
@@ -143,7 +144,6 @@ if depth_files or polygon_file:
                 value=6, key=f"mo_{i}",
                 help="Month of flood to compare against crop growing season"
             )
-            label = os.path.splitext(os.path.basename(path))[0]
             label_to_filename[label] = f.name
             label_to_metadata[label] = {"return_period": rp, "flood_month": mo}
 
@@ -166,7 +166,7 @@ if depth_files or polygon_file:
         )
 
         depth_arr = rasterize_polygon_to_array(poly_path, st.session_state.crop_path)
-        label = os.path.splitext(os.path.basename(poly_path))[0]
+        label = os.path.splitext(os.path.basename(polygon_file.name))[0]
         depth_inputs.append((label, depth_arr))
         label_to_filename[label] = polygon_file.name
         label_to_metadata[label] = {"return_period": rp, "flood_month": mo}

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -75,6 +75,27 @@ def test_process_flood_damage_generates_outputs(tmp_path):
     assert rasters["floodA"].shape == crop.shape
 
 
+def test_process_flood_damage_with_labeled_path(tmp_path):
+    crop = np.array([[1, 2], [2, 1]], dtype=np.uint16)
+    crop_path = tmp_path / "crop.tif"
+    create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 2, 1, 1))
+
+    depth_arr = np.full((2, 2), 6.0, dtype=float)
+    depth_path = tmp_path / "depthA.tif"
+    create_raster(depth_path, depth_arr, "EPSG:4326", from_origin(0, 2, 1, 1))
+
+    crop_inputs = {1: {"Value": 10, "GrowingSeason": [6]}, 2: {"Value": 20, "GrowingSeason": [6]}}
+    flood_metadata = {"depthA": {"return_period": 10, "flood_month": 6}}
+
+    out_dir = tmp_path / "out"
+    excel_path, summaries, diagnostics, rasters = process_flood_damage(
+        str(crop_path), [("depthA", str(depth_path))], str(out_dir), 100, crop_inputs, flood_metadata
+    )
+
+    assert (out_dir / "damage_depthA.tif").exists()
+    assert "depthA" in summaries
+
+
 def test_rasterize_polygon_zipped_shapefile(tmp_path):
     crop = np.zeros((10, 10), dtype=np.uint16)
     crop_path = tmp_path / "crop.tif"

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -103,12 +103,20 @@ def process_flood_damage(crop_path, depth_inputs, output_dir, period_years, crop
 
     for item in depth_inputs:
         if isinstance(item, tuple):
-            label, depth_arr = item
+            label, data = item
             meta = flood_metadata.get(label, {})
             return_period = meta.get("return_period", 100)
             flood_month = meta.get("flood_month", 6)
-            aligned_crop = base_crop_arr
-            crop_profile = base_crop_profile
+
+            if isinstance(data, np.ndarray):
+                depth_arr = data
+                aligned_crop = base_crop_arr
+                crop_profile = base_crop_profile
+            else:
+                depth_path = data
+                aligned_crop, crop_profile = align_crop_to_depth(crop_path, depth_path)
+                with rasterio.open(depth_path) as depth_src:
+                    depth_arr = depth_src.read(1, out_shape=(aligned_crop.shape), resampling=Resampling.bilinear)
         else:
             depth_path = item
             label = os.path.splitext(os.path.basename(depth_path))[0]


### PR DESCRIPTION
## Summary
- keep original file names for uploaded flood rasters and polygons
- document that polygon file names appear in results
- allow process_flood_damage to accept (label, path) tuples
- add regression test for labeled depth raster

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a53ee16d08330be66cb1eecc888c5