### PR TITLE
Rasterize polygons into crop grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If paths are supplied, the application reads the files directly with `rasterio`,
 
 ## Polygon Uploads
 
-You may also provide a polygon layer (zipped Shapefile, GeoJSON, or KML) instead of a flood depth raster. Cells of the crop raster inside the polygon are assumed to receive **0.5&nbsp;ft** (6&nbsp;inches) of flooding. The original file names of uploaded rasters and polygons become the labels in the output Excel workbook.
+You may also provide a polygon layer (zipped Shapefile, GeoJSON, or KML) instead of a flood depth raster. Polygons are rasterized onto the crop raster grid, and cells inside the polygon are assumed to receive **0.5&nbsp;ft** (6&nbsp;inches) of flooding. The original file names of uploaded rasters and polygons become the labels in the output Excel workbook.
 
 
 ## Running Tests


### PR DESCRIPTION
## Summary
- rasterize polygons with rasterio.features.rasterize instead of shapely grid checks
- mention polygon rasterization in README
- test GeoJSON and KML polygon handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bb28e54f48330836f25b94b70aff2