### PR TITLE
Add uniform flood input and manual masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ You may either upload `.tif` files directly in the sidebar or provide paths to e
 
 If paths are supplied, the application reads the files directly with `rasterio`, bypassing Streamlit's upload size limit.
 
-## Polygon Uploads
+## Uniform Depth Option
 
-You may also provide a polygon layer (zipped Shapefile, GeoJSON, or KML) instead of a flood depth raster. Polygons are rasterized onto the crop raster grid, and cells inside the polygon are assumed to receive **0.5&nbsp;ft** (6&nbsp;inches) of flooding. The original file names of uploaded rasters and polygons become the labels in the output Excel workbook.
+Instead of supplying a polygon to define flooded areas, you can enable the *Uniform Flood Depth* checkbox and enter a depth value in feet. The app will duplicate the crop raster and assign the specified depth to every pixel.
+
+## Manual Depth Painting
+
+If you prefer to sketch flooded areas directly, enable **Manual Depth Painting** in the sidebar. Choose a depth (in 0.5&nbsp;ft increments) and draw polygons on the interactive map. Each polygon is rasterized with its selected depth and treated like any other depth grid when calculating damages.
 
 
 ## Running Tests

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import os
@@ -16,6 +17,8 @@ from utils.processing import (
     align_crop_to_depth,
     process_flood_damage,
     polygon_mask_to_depth_array,
+    constant_depth_array,
+    drawn_features_to_depth_array,
 )
 
 
@@ -65,7 +68,12 @@ def test_process_flood_damage_generates_outputs(tmp_path):
 
     out_dir = tmp_path / "out"
     excel_path, summaries, diagnostics, rasters = process_flood_damage(
-        str(crop_path), [("floodA", depth_arr)], str(out_dir), 100, crop_inputs, flood_metadata
+        str(crop_path),
+        [("floodA", depth_arr)],
+        str(out_dir),
+        100,
+        crop_inputs,
+        flood_metadata,
     )
 
     assert os.path.exists(excel_path)
@@ -86,12 +94,20 @@ def test_process_flood_damage_with_labeled_path(tmp_path):
     depth_path = tmp_path / "depthA.tif"
     create_raster(depth_path, depth_arr, "EPSG:4326", from_origin(0, 2, 1, 1))
 
-    crop_inputs = {1: {"Value": 10, "GrowingSeason": [6]}, 2: {"Value": 20, "GrowingSeason": [6]}}
+    crop_inputs = {
+        1: {"Value": 10, "GrowingSeason": [6]},
+        2: {"Value": 20, "GrowingSeason": [6]},
+    }
     flood_metadata = {"depthA": {"return_period": 10, "flood_month": 6}}
 
     out_dir = tmp_path / "out"
     excel_path, summaries, diagnostics, rasters = process_flood_damage(
-        str(crop_path), [("depthA", str(depth_path))], str(out_dir), 100, crop_inputs, flood_metadata
+        str(crop_path),
+        [("depthA", str(depth_path))],
+        str(out_dir),
+        100,
+        crop_inputs,
+        flood_metadata,
     )
 
     assert (out_dir / "damage_depthA.tif").exists()
@@ -151,4 +167,33 @@ def test_rasterize_polygon_kml(tmp_path):
     arr = polygon_mask_to_depth_array(str(kml_path), str(crop_path))
     assert arr.shape == crop.shape
     assert arr.max() == 0.5
+    assert arr.sum() > 0
+
+
+def test_constant_depth_array(tmp_path):
+    crop = np.zeros((5, 5), dtype=np.uint16)
+    crop_path = tmp_path / "crop.tif"
+    create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 5, 1, 1))
+
+    arr = constant_depth_array(str(crop_path), depth_value=0.5)
+
+    assert arr.shape == crop.shape
+    assert np.allclose(arr, 0.5)
+
+
+def test_drawn_features_to_depth_array(tmp_path):
+    crop = np.zeros((10, 10), dtype=np.uint16)
+    crop_path = tmp_path / "crop.tif"
+    create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 10, 1, 1))
+
+    feature = {
+        "type": "Feature",
+        "properties": {"depth": 1.0},
+        "geometry": box(2, 2, 5, 5).__geo_interface__,
+    }
+
+    arr = drawn_features_to_depth_array([feature], str(crop_path))
+
+    assert arr.shape == crop.shape
+    assert arr.max() == 1.0
     assert arr.sum() > 0


### PR DESCRIPTION
## Summary
- replace fixed 6-inch option with user-specified uniform depth input
- introduce Manual Depth Painting to sketch polygons with per-depth brushes
- add `drawn_features_to_depth_array` utility
- update tests and docs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cdba954c88330a54d7e2fc2338efa