### PR TITLE
Ensure damage summaries include all crop types

### DIFF
--- a/utils/processing.py
+++ b/utils/processing.py
@@ -165,20 +165,29 @@ def process_flood_damage(
         damage_ratio = np.clip(depth_arr / FULL_DAMAGE_DEPTH_FT, 0, 1)
 
         for code, props in crop_inputs.items():
-            if flood_month not in props["GrowingSeason"]:
-                diagnostics.append(
-                    {"Flood": label, "CropCode": code, "Issue": "Out of season"}
-                )
-                continue
-
-            mask = aligned_crop == code
-            if not np.any(mask):
-                diagnostics.append(
-                    {"Flood": label, "CropCode": code, "Issue": "Not present"}
-                )
-                continue
-
             value = props["Value"]
+            mask = aligned_crop == code
+            out_of_season = flood_month not in props["GrowingSeason"]
+            not_present = not np.any(mask)
+
+            if out_of_season or not_present:
+                issue = "Out of season" if out_of_season else "Not present"
+                diagnostics.append(
+                    {"Flood": label, "CropCode": code, "Issue": issue}
+                )
+                rows.append(
+                    {
+                        "CropCode": code,
+                        "FloodedAcres": 0,
+                        "ValuePerAcre": value,
+                        "DollarsLost": 0.0,
+                        "EAD": 0.0,
+                        "ReturnPeriod": return_period,
+                        "FloodMonth": flood_month,
+                    }
+                )
+                continue
+
             crop_damage = value * damage_ratio * mask
             avg_damage = crop_damage.sum()
             ead = avg_damage * (1 / return_period)


### PR DESCRIPTION
## Summary
- Include out-of-season and missing crop codes in damage summaries with zero losses
- Mirror the same behavior in the ArcGIS toolbox implementation
- Test that summaries report every crop type

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b71057b708330a0e8c3d80c1e15c8