### PR TITLE
Expand crop coverage and add damage charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This Streamlit app estimates agricultural flood damages from cropland and flood depth rasters.
 
+The interface now reports **all** crop codes present in the uploaded raster and
+displays bar chart visualizations of damages for quick comparison between crop
+types.
+
 ## Usage
 
 1. Install requirements:

--- a/app.py
+++ b/app.py
@@ -131,7 +131,7 @@ if crop_file:
     with rasterio.open(crop_path) as src:
         arr = src.read(1)
     counts = Counter(arr.flatten())
-    codes = [c for c, _ in counts.most_common(50) if c != 0]
+    codes = [c for c, _ in counts.most_common() if c != 0]
 
     st.markdown("### 🌱 Crop Values and Growing Seasons")
     for code in codes:
@@ -311,6 +311,11 @@ if mode == "Direct Damages":
                 """
                 )
             st.dataframe(df)
+            chart_data = (
+                df.sort_values("DollarsLost", ascending=False)
+                .set_index("CropCode")["DollarsLost"]
+            )
+            st.bar_chart(chart_data)
 
         if st.session_state.diagnostics:
             st.subheader("🛠️ Diagnostics")
@@ -378,6 +383,11 @@ elif mode == "Monte Carlo Simulation":
                             """
                             )
                         st.dataframe(df)
+                        chart_data = (
+                            df.sort_values("EAD_MC_Mean", ascending=False)
+                            .set_index("CropCode")["EAD_MC_Mean"]
+                        )
+                        st.bar_chart(chart_data)
 
                     with pd.ExcelWriter(
                         result_path, mode="a", engine="openpyxl"


### PR DESCRIPTION
## Summary
- Include every crop code from the raster instead of truncating to a subset
- Add bar chart visualizations for deterministic and Monte Carlo results
- Note full crop reporting and new charts in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b78ce52c483308c4d115aa611b55e