### PR TITLE
Visualize damaged crops and include charts in Excel

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -83,7 +83,8 @@ def test_process_flood_damage_generates_outputs(tmp_path):
     df = summaries["floodA"]
     assert len(df) == 2
     assert diagnostics == []
-    assert rasters["floodA"].shape == crop.shape
+    assert rasters["floodA"]["ratio"].shape == crop.shape
+    assert set(np.unique(rasters["floodA"]["crop"])) == {1, 2}
 
 
 def test_process_flood_damage_with_labeled_path(tmp_path):
@@ -231,7 +232,7 @@ def test_process_flood_damage_excludes_zero_code(tmp_path):
 
     df = summaries["flood"]
     assert set(df["CropCode"]) == {1}
-    assert np.all(rasters["flood"][crop == 0] == 0)
+    assert np.all(rasters["flood"]["ratio"][crop == 0] == 0)
 
 def test_rasterize_polygon_zipped_shapefile(tmp_path):
     crop = np.zeros((10, 10), dtype=np.uint16)

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -252,7 +252,12 @@ def process_flood_damage(
 
         df = pd.DataFrame(rows)
         summaries[label] = df
-        damage_rasters[label] = damage_arr
+
+        damage_crop_arr = np.where(damage_arr > 0, aligned_crop, 0)
+        damage_rasters[label] = {
+            "ratio": damage_arr,
+            "crop": damage_crop_arr,
+        }
 
         with rasterio.open(
             os.path.join(output_dir, f"damage_{label}.tif"), "w", **crop_profile


### PR DESCRIPTION
## Summary
- Display damaged areas by crop type instead of damage ratios.
- Save bar charts and raster visualizations and embed them in the Excel export.
- Add tests for new crop-type raster output.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b81cd14108330b719c81fe037bbc0