### PR TITLE
Remove manual depth painting and show crop-type damage maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,9 @@ If paths are supplied, the application reads the files directly with `rasterio`,
 
 Instead of supplying a polygon to define flooded areas, you can enable the *Uniform Flood Depth* checkbox and enter a depth value in feet. The app will duplicate the crop raster and assign the specified depth to every pixel.
 
-## Manual Depth Painting
+## Damage Map Visualization
 
-If you prefer to sketch flooded areas directly, enable **Manual Depth Painting** in the sidebar. Choose a depth (in 0.5&nbsp;ft increments) and draw polygons on the interactive map. Each polygon is rasterized with its selected depth and treated like any other depth grid when calculating damages.
-
+Output maps color-code damaged areas by crop type and include a legend with crop names for easy interpretation.
 
 ## Running Tests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,3 @@ fiona>=1.9
 openpyxl>=3.1
 matplotlib>=3.7
 scipy>=1.10.0
-folium>=0.14
-branca>=0.6
-streamlit-folium>=0.11


### PR DESCRIPTION
## Summary
- drop manual flood depth painting and related dependencies
- allow naming of crop codes and visualize damage maps by crop type with legend
- simplify requirements to core geospatial stack

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a76de6a0988330914aba8e25b9c6ea