### PR TITLE
Fix Streamlit number_input mixed type error

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,10 +145,15 @@ if crop_file:
             key=f"name_{code}",
             help="Descriptive name for this crop code",
         )
+        # Streamlit's number_input requires all numeric parameters to share the
+        # same type (int vs. float).  ``default_val`` is cast to ``float`` above,
+        # but ``step`` was provided as an ``int`` which triggered a
+        # StreamlitMixedNumericTypesError.  Use a float for ``step`` so the value
+        # and step have matching types.
         val = st.number_input(
             f"{name} – $/Acre",
             value=float(default_val or 0),
-            step=100,
+            step=100.0,
             key=f"val_{code}",
             help="Enter average crop value per acre for this crop",
         )


### PR DESCRIPTION
## Summary
- prevent `StreamlitMixedNumericTypesError` by using a float step for crop value inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77026af408330a0c0cf87ab6db7b9