### PR TITLE
feat: allow precise crop values

### DIFF
--- a/app.py
+++ b/app.py
@@ -147,15 +147,14 @@ if crop_file:
             key=f"name_{code}",
             help="Descriptive name for this crop code",
         )
-        # Streamlit's number_input requires all numeric parameters to share the
-        # same type (int vs. float).  ``default_val`` is cast to ``float`` above,
-        # but ``step`` was provided as an ``int`` which triggered a
-        # StreamlitMixedNumericTypesError.  Use a float for ``step`` so the value
-        # and step have matching types.
+        # ``default_val`` is cast to ``float`` above, so ``step`` must also be a
+        # float. Use a small increment and explicit format so precise dollar
+        # amounts (e.g., 1193.19) are preserved instead of being rounded.
         val = st.number_input(
             f"{name} – $/Acre",
             value=float(default_val or 0),
-            step=100.0,
+            step=0.01,
+            format="%.2f",
             key=f"val_{code}",
             help="Enter average crop value per acre for this crop",
         )


### PR DESCRIPTION
## Summary
- reduce step size in crop value number input and add decimal formatting to avoid rounding

## Testing
- `pytest -q`
- `python - <<'PY'
from streamlit.testing.v1 import AppTest

script = '''
import streamlit as st
v = st.number_input("Rice", value=0.0, step=0.01, format="%.2f", key="rice")
st.write(v)
'''

at = AppTest.from_string(script)
at.run()
at.number_input(key="rice").set_value(1193.19).run()
at.run()
print(at.session_state.rice)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b778573f808330841987706159a5de