### PR TITLE
Add flood month uncertainty to Monte Carlo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ A Python toolbox named `flood_damage_toolbox.pyt` is provided for running the mo
 2. Open the **Flood Damage Estimator** tool.
 3. Provide a crop raster, one or more depth rasters, a CSV with crop codes, values and growing seasons, and an output folder.
 4. Enter a return period and flood month for **each** depth raster (the lists must match in length).
-5. Optionally enable Monte Carlo simulation and adjust the uncertainty parameters.
+5. Optionally enable Monte Carlo simulation and adjust the uncertainty parameters, including a setting to randomize the flood month so events can occur in any part of the year.
 
 The tool writes an Excel summary in the chosen output folder, mirroring the results of the Streamlit application.
 

--- a/app.py
+++ b/app.py
@@ -123,6 +123,11 @@ value_sd = st.sidebar.number_input(
     value=10,
     help="Assumed variability in per-acre crop values (used only in Monte Carlo)",
 )
+month_uncertainty = st.sidebar.checkbox(
+    "📅 Randomize Flood Month",
+    value=False,
+    help="If checked, Monte Carlo simulations will sample flood months uniformly across the year",
+)
 
 crop_inputs, label_to_filename, label_to_metadata = {}, {}, {}
 
@@ -376,6 +381,7 @@ elif mode == "Monte Carlo Simulation":
                         samples,
                         value_sd,
                         depth_sd,
+                        month_uncertainty,
                     )
                     st.session_state.result_path = result_path
 


### PR DESCRIPTION
## Summary
- allow Monte Carlo simulations to randomize flood month and skip losses outside crop growing seasons
- surface new month randomization option in the Streamlit app and include crop growing seasons in summaries
- test month-based uncertainty and document the new capability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77ac774f483309b784b0abdbdf132