### PR TITLE
Use defined crop values instead of defaults

### DIFF
--- a/flood_damage_toolbox.pyt
+++ b/flood_damage_toolbox.pyt
@@ -41,6 +41,10 @@ except Exception:  # pragma: no cover - ArcGIS Pro may lack rasterio
             for code, props in crop_inputs.items():
                 # Default to the crop code string when a definition is missing
                 props.setdefault("Name", CROP_DEFINITIONS.get(code, (str(code), 0))[0])
+                if code in CROP_DEFINITIONS:
+                    props["Value"] = CROP_DEFINITIONS[code][1]
+                else:
+                    props.setdefault("Value", 0)
 
         os.makedirs(output_dir, exist_ok=True)
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -197,6 +197,26 @@ def test_process_flood_damage_includes_unlisted_crops(tmp_path):
     assert name == "999"
 
 
+def test_process_flood_damage_uses_defined_values(tmp_path):
+    crop = np.array([[3]], dtype=np.uint16)
+    crop_path = tmp_path / "crop.tif"
+    create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 1, 1, 1))
+
+    depth_arr = np.full((1, 1), 6.0, dtype=float)
+    # Provide an incorrect default value that should be overridden
+    crop_inputs = {3: {"Value": 1200, "GrowingSeason": [6]}}
+    flood_metadata = {"floodA": {"return_period": 10, "flood_month": 6}}
+
+    out_dir = tmp_path / "out"
+    _, summaries, _, _ = process_flood_damage(
+        str(crop_path), [("floodA", depth_arr)], str(out_dir), 100, crop_inputs, flood_metadata
+    )
+
+    df = summaries["floodA"]
+    val = df[df["CropCode"] == 3]["ValuePerAcre"].iloc[0]
+    assert val == CROP_DEFINITIONS[3][1]
+
+
 def test_pixel_to_acre_conversion(tmp_path):
     crop = np.array([[1]], dtype=np.uint16)
     pixel_size = 30  # meters
@@ -344,5 +364,5 @@ def test_run_monte_carlo_month_uncertainty(tmp_path):
     original_ead = summaries["floodA"].iloc[0]["EAD"]
     mc = run_monte_carlo(summaries, flood_metadata, 1000, 0, 0, month_uncertainty=True)
     mc_mean = mc["floodA"].iloc[0]["EAD_MC_Mean"]
-
-    assert mc_mean == pytest.approx(original_ead / 12, rel=0.2)
+    expected = round(original_ead / 12, 2)
+    assert mc_mean == pytest.approx(expected, rel=0.2)

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -151,6 +151,10 @@ def process_flood_damage(
         crop_inputs = {k: v for k, v in crop_inputs.items() if k != 0}
         for code, props in crop_inputs.items():
             props.setdefault("Name", CROP_DEFINITIONS.get(code, (str(code), 0))[0])
+            if code in CROP_DEFINITIONS:
+                props["Value"] = CROP_DEFINITIONS[code][1]
+            else:
+                props.setdefault("Value", 0)
         for code in crop_codes_present:
             if code not in crop_inputs:
                 name, value = CROP_DEFINITIONS.get(code, (str(code), 0))


### PR DESCRIPTION
## Summary
- Override provided crop values with definition data so each crop uses its official value
- Mirror value override in ArcGIS toolbox fallback
- Test that crops fall back to definitions instead of a 1200/acre default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b77d80c9fc833094164f2b1fa5881d