### PR TITLE
Respect user-provided crop values

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -197,13 +197,13 @@ def test_process_flood_damage_includes_unlisted_crops(tmp_path):
     assert name == "999"
 
 
-def test_process_flood_damage_uses_defined_values(tmp_path):
+def test_process_flood_damage_respects_user_values(tmp_path):
     crop = np.array([[3]], dtype=np.uint16)
     crop_path = tmp_path / "crop.tif"
     create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 1, 1, 1))
 
     depth_arr = np.full((1, 1), 6.0, dtype=float)
-    # Provide an incorrect default value that should be overridden
+    # Provide a custom value that should be preserved
     crop_inputs = {3: {"Value": 1200, "GrowingSeason": [6]}}
     flood_metadata = {"floodA": {"return_period": 10, "flood_month": 6}}
 
@@ -214,7 +214,7 @@ def test_process_flood_damage_uses_defined_values(tmp_path):
 
     df = summaries["floodA"]
     val = df[df["CropCode"] == 3]["ValuePerAcre"].iloc[0]
-    assert val == CROP_DEFINITIONS[3][1]
+    assert val == 1200
 
 
 def test_pixel_to_acre_conversion(tmp_path):

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -150,11 +150,9 @@ def process_flood_damage(
     else:
         crop_inputs = {k: v for k, v in crop_inputs.items() if k != 0}
         for code, props in crop_inputs.items():
-            props.setdefault("Name", CROP_DEFINITIONS.get(code, (str(code), 0))[0])
-            if code in CROP_DEFINITIONS:
-                props["Value"] = CROP_DEFINITIONS[code][1]
-            else:
-                props.setdefault("Value", 0)
+            default_name, default_value = CROP_DEFINITIONS.get(code, (str(code), 0))
+            props.setdefault("Name", default_name)
+            props.setdefault("Value", default_value)
         for code in crop_codes_present:
             if code not in crop_inputs:
                 name, value = CROP_DEFINITIONS.get(code, (str(code), 0))


### PR DESCRIPTION
## Summary
- Avoid overriding user-supplied crop values with defaults from `CROP_DEFINITIONS`
- Update processing tests to confirm custom crop values are preserved

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77f8656508330b86d7215e85b5039