### PR TITLE
Add Flooded Pixels column to damage summaries

### DIFF
--- a/app.py
+++ b/app.py
@@ -283,7 +283,8 @@ if mode == "Direct Damages":
                     """
                 - **CropCode**: CropScape numerical code.
                 - **CropName**: Descriptive crop type.
-                - **FloodedAcres**: Area affected (1 pixel ≈ 0.222 acres).
+                - **FloodedPixels**: Number of inundated pixels.
+                - **FloodedAcres**: Area affected (pixels × pixel area; 1 pixel ≈ 0.222 acres).
                 - **ValuePerAcre**: Input value per acre for the crop.
                 - **DollarsLost**: Total crop damage.
                 - **EAD**: Expected Annual Damage = DollarsLost ÷ ReturnPeriod.

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -83,6 +83,7 @@ def test_process_flood_damage_generates_outputs(tmp_path):
     assert "floodA" in summaries
     df = summaries["floodA"]
     assert len(df) == 2
+    assert "FloodedPixels" in df.columns
     assert diagnostics == []
     assert rasters["floodA"]["ratio"].shape == crop.shape
     assert set(np.unique(rasters["floodA"]["crop"])) == {1, 2}
@@ -143,6 +144,7 @@ def test_process_flood_damage_reports_all_crops(tmp_path):
     assert set(df["CropCode"]) == {1, 2}
     row2 = df[df["CropCode"] == 2].iloc[0]
     assert row2["FloodedAcres"] == 0
+    assert row2["FloodedPixels"] == 0
     assert row2["DollarsLost"] == 0
     assert any(d["CropCode"] == 2 for d in diagnostics)
 
@@ -241,8 +243,10 @@ def test_pixel_to_acre_conversion(tmp_path):
 
     df = summaries["floodA"]
     expected = (pixel_size * pixel_size) / 4046.8564224
+    flooded_pixels = df[df["CropCode"] == 1]["FloodedPixels"].iloc[0]
     flooded_acres = df[df["CropCode"] == 1]["FloodedAcres"].iloc[0]
-    assert flooded_acres == pytest.approx(expected, rel=1e-3)
+    assert flooded_pixels == 1
+    assert flooded_acres == pytest.approx(flooded_pixels * expected, rel=1e-3)
 
 
 def test_process_flood_damage_excludes_zero_code(tmp_path):

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -235,6 +235,7 @@ def process_flood_damage(
                     {
                         "CropCode": code,
                         "CropName": name,
+                        "FloodedPixels": 0,
                         "FloodedAcres": 0.0,
                         "ValuePerAcre": value,
                         "DollarsLost": 0.0,
@@ -246,7 +247,8 @@ def process_flood_damage(
                 )
                 continue
 
-            flooded_acres = mask.sum() * pixel_area_acres
+            flooded_pixels = int(mask.sum())
+            flooded_acres = flooded_pixels * pixel_area_acres
             crop_damage = value * damage_ratio * mask * pixel_area_acres
             avg_damage = crop_damage.sum()
             ead = avg_damage * (1 / return_period)
@@ -256,6 +258,7 @@ def process_flood_damage(
                 {
                     "CropCode": code,
                     "CropName": name,
+                    "FloodedPixels": flooded_pixels,
                     "FloodedAcres": flooded_acres,
                     "ValuePerAcre": value,
                     "DollarsLost": round(avg_damage, 2),


### PR DESCRIPTION
## Summary
- Track raw flooded pixel counts and compute acres from them
- Document FloodedPixels column in Streamlit app
- Extend tests to verify pixel-to-acre conversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b43e54788330a3eeb2a06adaed68