### PR TITLE
Align crop raster to depth grid

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -50,9 +50,10 @@ def test_align_crop_to_depth_crs_and_shape(tmp_path):
     create_raster(depth_path, depth_arr, "EPSG:3857", depth_transform)
 
     aligned, profile = align_crop_to_depth(str(crop_path), str(depth_path))
-
-    assert aligned.shape == crop_arr.shape
+    
+    assert aligned.shape == depth_arr.shape
     assert str(profile["crs"]) == "EPSG:3857"
+    assert profile["transform"] == depth_transform
 
 
 def test_process_flood_damage_generates_outputs(tmp_path):

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -3,7 +3,7 @@ import numpy as np
 import pandas as pd
 import rasterio
 from rasterio.enums import Resampling
-from rasterio.warp import calculate_default_transform, reproject
+from rasterio.warp import reproject
 from rasterio import features
 import geopandas as gpd
 from shapely.geometry import shape
@@ -26,9 +26,10 @@ SQ_METERS_TO_ACRES = 0.000247105
 def align_crop_to_depth(crop_path, depth_path):
     with rasterio.open(depth_path) as depth_src, rasterio.open(crop_path) as crop_src:
         dst_crs = depth_src.crs
-        dst_transform, width, height = calculate_default_transform(
-            crop_src.crs, dst_crs, crop_src.width, crop_src.height, *crop_src.bounds
-        )
+        dst_transform = depth_src.transform
+        width = depth_src.width
+        height = depth_src.height
+
         profile = crop_src.profile.copy()
         profile.update(
             {


### PR DESCRIPTION
## Summary
- reproject crop rasters using depth grid's transform and dimensions for proper alignment
- test alignment ensures CRS and grid spacing match depth raster

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c07e68548330a9b2c7564fa674ab