### PR TITLE
Use float32 profile for damage rasters

### DIFF
--- a/utils/processing.py
+++ b/utils/processing.py
@@ -278,14 +278,18 @@ def process_flood_damage(
         df = pd.DataFrame(rows)
         summaries[label] = df
 
+        damage_arr = damage_arr.astype(np.float32)
         damage_crop_arr = np.where(damage_arr > 0, aligned_crop, 0)
         damage_rasters[label] = {
             "ratio": damage_arr,
             "crop": damage_crop_arr,
         }
 
+        damage_profile = crop_profile.copy()
+        damage_profile["dtype"] = "float32"
+
         with rasterio.open(
-            os.path.join(output_dir, f"damage_{label}.tif"), "w", **crop_profile
+            os.path.join(output_dir, f"damage_{label}.tif"), "w", **damage_profile
         ) as dst:
             dst.write(damage_arr, 1)
 


### PR DESCRIPTION
## Summary
- Ensure damage raster writes use a float32 profile
- Cast damage arrays to float32 before saving

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c2c10cdc8330a5b4b59060f51884