### PR TITLE
Store damage rasters on disk

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,7 +31,7 @@ for key in [
     "diagnostics",
     "crop_path",
     "depth_inputs",
-    "damage_rasters",
+    "damage_raster_paths",
     "label_map",
     "label_metadata",
     "crop_inputs",
@@ -253,7 +253,7 @@ if mode == "Direct Damages":
             st.session_state.temp_dir = tempfile.TemporaryDirectory()
             with st.spinner("🔄 Processing flood damages..."):
                 try:
-                    result_path, summaries, diagnostics, damage_rasters = (
+                    result_path, summaries, diagnostics, damage_raster_paths = (
                         process_flood_damage(
                             st.session_state.crop_path,
                             st.session_state.depth_inputs,
@@ -266,12 +266,12 @@ if mode == "Direct Damages":
                     st.session_state.result_path = result_path
                     st.session_state.summaries = summaries
                     st.session_state.diagnostics = diagnostics
-                    st.session_state.damage_rasters = damage_rasters
+                    st.session_state.damage_raster_paths = damage_raster_paths
                     st.success("✅ Direct damage analysis complete.")
                 except Exception as e:
                     st.error(f"❌ Error: {e}")
 
-    if st.session_state.result_path and "damage_rasters" in st.session_state:
+    if st.session_state.result_path and "damage_raster_paths" in st.session_state:
         st.markdown("---")
         st.header("📈 Results & Visualizations")
 
@@ -315,9 +315,10 @@ if mode == "Direct Damages":
             st.subheader("🛠️ Diagnostics")
             st.dataframe(pd.DataFrame(st.session_state.diagnostics))
 
-        for label, arrs in st.session_state.damage_rasters.items():
+        for label, paths in st.session_state.damage_raster_paths.items():
             st.subheader(f"🗺️ Damage Raster – {label}")
-            crop_arr = arrs.get("crop") if isinstance(arrs, dict) else arrs
+            with rasterio.open(paths.get("crop")) as src:
+                crop_arr = src.read(1)
             codes = [c for c in np.unique(crop_arr) if c != 0]
             name_map = {
                 c: st.session_state.crop_inputs.get(c, {}).get(
@@ -380,7 +381,7 @@ elif mode == "Monte Carlo Simulation":
             st.session_state.temp_dir = tempfile.TemporaryDirectory()
             with st.spinner("🔬 Running Monte Carlo..."):
                 try:
-                    result_path, summaries, diagnostics, damage_rasters = (
+                    result_path, summaries, diagnostics, damage_raster_paths = (
                         process_flood_damage(
                             st.session_state.crop_path,
                             st.session_state.depth_inputs,

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -88,8 +88,10 @@ def test_process_flood_damage_generates_outputs(tmp_path):
     assert len(df) == 2
     assert "FloodedPixels" in df.columns
     assert diagnostics == []
-    assert rasters["floodA"]["ratio"].shape == crop.shape
-    assert set(np.unique(rasters["floodA"]["crop"])) == {1, 2}
+    with rasterio.open(rasters["floodA"]["ratio"]) as src:
+        assert src.read(1).shape == crop.shape
+    with rasterio.open(rasters["floodA"]["crop"]) as src:
+        assert set(np.unique(src.read(1))) == {1, 2}
 
 
 def test_process_flood_damage_with_labeled_path(tmp_path):
@@ -315,7 +317,9 @@ def test_process_flood_damage_excludes_zero_code(tmp_path):
 
     df = summaries["flood"]
     assert set(df["CropCode"]) == {1}
-    assert np.all(rasters["flood"]["ratio"][crop == 0] == 0)
+    with rasterio.open(rasters["flood"]["ratio"]) as src:
+        arr = src.read(1)
+        assert np.all(arr[crop == 0] == 0)
 
 def test_rasterize_polygon_zipped_shapefile(tmp_path):
     crop = np.zeros((10, 10), dtype=np.uint16)


### PR DESCRIPTION
## Summary
- Avoid keeping large damage raster arrays in memory by writing them to temporary GeoTIFFs and returning file paths
- Update Streamlit app to use damage raster paths on demand, reducing session state size
- Adjust tests to read rasters from disk

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c78d714883309a2f926c27d1fdc6