### PR TITLE
Avoid invalid escape warning in sanitize_label

### DIFF
--- a/utils/processing.py
+++ b/utils/processing.py
@@ -28,7 +28,7 @@ INVALID_SHEET_CHARS = r"[\[\]:\*\?/\\]"
 
 
 def sanitize_label(label, max_length=31):
-    """Return a filesystem and Excel-safe version of *label*.
+    r"""Return a filesystem and Excel-safe version of *label*.
 
     Excel sheet names cannot contain ``[]:*?/\`` and must be <=31 characters.
     This helper replaces forbidden characters with underscores and truncates


### PR DESCRIPTION
## Summary
- mark sanitize_label docstring as a raw string to prevent invalid escape sequence warnings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8c94557a48330940f95de3589e8a7