### PR TITLE
Validate depth array shape in process_flood_damage

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -145,6 +145,25 @@ def test_process_flood_damage_sanitizes_labels(tmp_path):
         assert ch not in safe_label
 
 
+def test_process_flood_damage_raises_on_shape_mismatch(tmp_path):
+    crop = np.array([[1, 1], [1, 1]], dtype=np.uint16)
+    crop_path = tmp_path / "crop.tif"
+    create_raster(crop_path, crop, "EPSG:4326", from_origin(0, 2, 1, 1))
+
+    depth_arr = np.zeros((1, 1), dtype=float)
+    crop_inputs = {1: {"Value": 10, "GrowingSeason": [6]}}
+    out_dir = tmp_path / "out"
+    with pytest.raises(ValueError, match="align"):
+        process_flood_damage(
+            str(crop_path),
+            [("flood", depth_arr)],
+            str(out_dir),
+            100,
+            crop_inputs,
+            {},
+        )
+
+
 def test_process_flood_damage_reports_all_crops(tmp_path):
     crop = np.array([[1, 1], [1, 1]], dtype=np.uint16)
     crop_path = tmp_path / "crop.tif"

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -160,6 +160,7 @@ def process_flood_damage(
 
     with rasterio.open(crop_path) as base_crop_src:
         base_crop_profile = base_crop_src.profile.copy()
+        base_crop_shape = base_crop_src.read(1).shape
         unique_codes = set()
         for _, window in base_crop_src.block_windows(1):
             block = base_crop_src.read(1, window=window)
@@ -209,6 +210,11 @@ def process_flood_damage(
 
                     if isinstance(data, np.ndarray):
                         depth_arr = data.astype("float32")
+                        if depth_arr.shape != base_crop_shape:
+                            raise ValueError(
+                                f"Depth array shape {depth_arr.shape} does not match crop raster shape {base_crop_shape}. "
+                                "Please align inputs before processing."
+                            )
                         crop_profile = base_crop_profile
 
                         def read_depth(window, arr=depth_arr):


### PR DESCRIPTION
## Summary
- ensure depth arrays passed directly to `process_flood_damage` match the crop raster dimensions
- raise a helpful `ValueError` instructing users to align inputs when shapes differ
- add regression test for mismatched array shapes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9b964d1dc8330bbab41660b023d1c