### PR TITLE
Replace deprecated colormap retrieval in damage raster view

### DIFF
--- a/app.py
+++ b/app.py
@@ -330,7 +330,7 @@ if mode == "Direct Damages":
                 )
                 for c in codes
             }
-            cmap = plt.cm.get_cmap("tab20", len(codes) or 1)
+            cmap = plt.get_cmap("tab20", len(codes) or 1)
             code_to_idx = {code: idx for idx, code in enumerate(codes)}
             indexed = np.vectorize(lambda x: code_to_idx.get(x, -1))(crop_arr)
             masked = np.ma.masked_where(crop_arr == 0, indexed)


### PR DESCRIPTION
## Summary
- use `plt.get_cmap` for damage raster rendering

## Testing
- `pytest`
- `python - <<'PY'
import warnings
import matplotlib.pyplot as plt
with warnings.catch_warnings(record=True) as w:
    cmap = plt.get_cmap('tab20', 5)
    print('warnings count', len(w))
    print('cmap name', cmap.name)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b9baae5c28833087434ccf87e3ad84