### PR TITLE
Fix missing CropName in Monte Carlo results

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -462,3 +462,4 @@ def test_run_monte_carlo_month_uncertainty(tmp_path):
     mc_mean = mc["floodA"].iloc[0]["EAD_MC_Mean"]
     expected = round(original_ead / 12, 2)
     assert mc_mean == pytest.approx(expected, rel=0.2)
+    assert "CropName" in mc["floodA"].columns

--- a/utils/processing.py
+++ b/utils/processing.py
@@ -452,6 +452,7 @@ def run_monte_carlo(
             rows.append(
                 {
                     "CropCode": row["CropCode"],
+                    "CropName": row["CropName"],
                     "EAD_MC_Mean": round(float(np.mean(losses)), 2),
                     "EAD_MC_5th": round(float(np.percentile(losses, 5)), 2),
                     "EAD_MC_95th": round(float(np.percentile(losses, 95)), 2),


### PR DESCRIPTION
## Summary
- Add CropName column to Monte Carlo result rows to prevent indexing errors
- Expand Monte Carlo test to ensure CropName column is present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9c1a631748330bcf835eebe46dae0